### PR TITLE
Rename to sql-impressao

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "sql-fingerprint-python"
+name = "sql-impressao"
 version = "0.1.0"
 dependencies = [
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "sql-fingerprint-python"
+name = "sql-impressao"
 version = "0.1.0"
 edition = "2021"
 
 [lib]
-name = "sql_fingerprint"
+name = "sql_impressao"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,12 @@
-========================
-sql-fingerprint (Python)
-========================
+=============
+sql-impressao
+=============
 
-.. image:: https://img.shields.io/github/actions/workflow/status/adamchainz/sql-fingerprint-python/main.yml.svg?branch=main&style=for-the-badge
-   :target: https://github.com/adamchainz/sql-fingerprint-python/actions?workflow=CI
+.. image:: https://img.shields.io/github/actions/workflow/status/adamchainz/sql-impressao/main.yml.svg?branch=main&style=for-the-badge
+   :target: https://github.com/adamchainz/sql-impressao/actions?workflow=CI
 
-.. image:: https://img.shields.io/pypi/v/sql-fingerprint-python.svg?style=for-the-badge
-   :target: https://pypi.org/project/sql-fingerprint-python/
+.. image:: https://img.shields.io/pypi/v/sql-impressao.svg?style=for-the-badge
+   :target: https://pypi.org/project/sql-impressao/
 
 .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white&style=for-the-badge
    :target: https://github.com/pre-commit/pre-commit
@@ -17,7 +17,7 @@ A quick example:
 
 .. code-block:: python-console
 
-    >>> from sql_fingerprint import fingerprint_one
+    >>> from sql_impressao import fingerprint_one
     >>> fingerprint_one('SELECT a, b FROM cheeses WHERE origin = "France" ORDER BY age DESC')
     'SELECT ... FROM cheeses WHERE ... ORDER BY ...'
 
@@ -34,7 +34,7 @@ With **pip**:
 
 .. code-block:: sh
 
-    python -m pip install sql-fingerprint
+    python -m pip install sql-impressao
 
 Python 3.9 to 3.13 supported.
 
@@ -63,7 +63,7 @@ Example:
 
 .. code-block:: python
 
-    from sql_fingerprint import fingerprint_one
+    from sql_impressao import fingerprint_one
 
     sql = 'SELECT a, b FROM cheeses WHERE origin = "France" ORDER BY age DESC'
     fingerprint = fingerprint_one(sql)
@@ -84,7 +84,7 @@ Example:
 
 .. code-block:: python
 
-    from sql_fingerprint import fingerprint_many
+    from sql_impressao import fingerprint_many
 
     sqls = ["SELECT a, b FROM c", "SELECT b, c FROM d"]
     fingerprints = fingerprint_many(sqls)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "maturin"
 requires = [ "maturin>=1.8,<2" ]
 
 [project]
-name = "sql-fingerprint"
+name = "sql-impressao"
 version = "0.1.0"
 description = "A SQL fingerprinter."
 readme = "README.rst"
@@ -28,9 +28,9 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-urls.Changelog = "https://github.com/adamchainz/sql-fingerprint-python/blob/main/CHANGELOG.rst"
+urls.Changelog = "https://github.com/adamchainz/sql-impressao/blob/main/CHANGELOG.rst"
 urls.Funding = "https://adamj.eu/books/"
-urls.Repository = "https://github.com/adamchainz/sql-fingerprint-python"
+urls.Repository = "https://github.com/adamchainz/sql-impressao"
 
 [dependency-groups]
 test = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use ::sql_fingerprint as upstream_fingerprint;
+use ::sql_fingerprint;
 use pyo3::prelude::*;
 use sqlparser::dialect::dialect_from_str;
 
@@ -6,7 +6,7 @@ use sqlparser::dialect::dialect_from_str;
 #[pyo3(signature = (sql, *, dialect = None))]
 fn fingerprint_one(sql: String, dialect: Option<String>) -> PyResult<String> {
     let parsed_dialect = parse_dialect(dialect)?;
-    Ok(upstream_fingerprint::fingerprint_one(
+    Ok(sql_fingerprint::fingerprint_one(
         sql.as_str(),
         parsed_dialect.as_deref(),
     ))
@@ -17,7 +17,7 @@ fn fingerprint_one(sql: String, dialect: Option<String>) -> PyResult<String> {
 fn fingerprint_many(sql: Vec<String>, dialect: Option<String>) -> PyResult<Vec<String>> {
     let parsed_dialect = parse_dialect(dialect)?;
     let sql_slices: Vec<&str> = sql.iter().map(|s| s.as_str()).collect();
-    Ok(upstream_fingerprint::fingerprint_many(
+    Ok(sql_fingerprint::fingerprint_many(
         sql_slices,
         parsed_dialect.as_deref(),
     ))
@@ -38,7 +38,7 @@ fn parse_dialect(
 }
 
 #[pymodule]
-fn sql_fingerprint(m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn sql_impressao(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(fingerprint_one, m)?)?;
     m.add_function(wrap_pyfunction!(fingerprint_many, m)?)?;
     Ok(())

--- a/tests/test_sql_impressao.py
+++ b/tests/test_sql_impressao.py
@@ -1,4 +1,4 @@
-from sql_fingerprint import fingerprint_many, fingerprint_one
+from sql_impressao import fingerprint_many, fingerprint_one
 
 
 def test_fingerprint_one():

--- a/uv.lock
+++ b/uv.lock
@@ -65,7 +65,7 @@ wheels = [
 ]
 
 [[package]]
-name = "sql-fingerprint"
+name = "sql-impressao"
 version = "0.1.0"
 source = { editable = "." }
 


### PR DESCRIPTION
sql-fingerprint was not allowed to be published on PyPI due to similarity with the existing sqlfingerprint, so going with a new name based on the Portuguese for fingerprint, impressão digital.