### PR TITLE
Stop shipping wheels for 32-bit Linux and Windows.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,8 +79,6 @@ jobs:
           # windows
           - os: windows
             target: x86_64
-          - os: windows
-            target: aarch64
 
     runs-on:
       ${{

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,6 @@ Changelog
 =========
 
 * Stop shipping wheels for 32-bit Linux and Windows.
-  Ship wheels for Windows on ARM.
 
   `PR #48 <https://github.com/adamchainz/sql-impressao/pull/48>`__.
 


### PR DESCRIPTION
Copy of https://github.com/adamchainz/time-machine/pull/605 for this repo, with the same reasoning.