### PR TITLE
Drop --find-intepreter from maturin invocation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
       with:
         target: ${{ matrix.target }}
         manylinux: ${{ matrix.manylinux || 'auto' }}
-        args: --release --locked --out dist --find-interpreter
+        args: --release --locked --out dist
 
     - run: ${{ (matrix.os == 'windows' && 'dir') || 'ls -lh' }} dist/
 


### PR DESCRIPTION
Not needed on my other projects...